### PR TITLE
Make batched skinning compile (still broken though)

### DIFF
--- a/crates/bevy_pbr/src/prepass/prepass.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass.wgsl
@@ -43,7 +43,7 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
 #endif
 
 #ifdef SKINNED
-    let skin_index = mesh[get_instance_index(vertex_no_morph.instance_index)].skin_index;
+    let skin_index = mesh[vertex_no_morph.instance_index].skin_index;
     var model = bevy_pbr::skinning::skin_model(skin_index, vertex.joint_indices, vertex.joint_weights);
 #else // SKINNED
     // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.

--- a/crates/bevy_pbr/src/render/mesh.wgsl
+++ b/crates/bevy_pbr/src/render/mesh.wgsl
@@ -38,7 +38,7 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
 #endif
 
 #ifdef SKINNED
-    let skin_index = mesh[get_instance_index(vertex_no_morph.instance_index)].skin_index;
+    let skin_index = mesh[vertex_no_morph.instance_index].skin_index;
     var model = bevy_pbr::skinning::skin_model(skin_index, vertex.joint_indices, vertex.joint_weights);
 #else
     // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.

--- a/crates/bevy_pbr/src/render/mesh_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_bindings.rs
@@ -19,7 +19,7 @@ mod layout_entry {
     use crate::MeshUniform;
     use bevy_render::{
         render_resource::{
-            binding_types::{sampler, texture_2d, texture_3d, uniform_buffer_sized},
+            binding_types::{sampler, storage_buffer_read_only_sized, texture_2d, texture_3d, uniform_buffer_sized},
             BindGroupLayoutEntryBuilder, BufferSize, GpuArrayBuffer, SamplerBindingType,
             ShaderStages, TextureSampleType,
         },
@@ -37,7 +37,11 @@ mod layout_entry {
         } else {
             JOINT_BUFFER_SIZE
         };
-        uniform_buffer_sized(!is_storage, BufferSize::new(min_binding_size as u64))
+        if is_storage {
+            storage_buffer_read_only_sized(!is_storage, BufferSize::new(min_binding_size as u64))
+        } else {
+            uniform_buffer_sized(!is_storage, BufferSize::new(min_binding_size as u64))
+        }
     }
     pub(super) fn weights() -> BindGroupLayoutEntryBuilder {
         uniform_buffer_sized(true, BufferSize::new(MORPH_BUFFER_SIZE as u64))

--- a/crates/bevy_pbr/src/render/wireframe.wgsl
+++ b/crates/bevy_pbr/src/render/wireframe.wgsl
@@ -34,7 +34,7 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
 #endif
 
 #ifdef SKINNED
-    let skin_index = mesh[get_instance_index(vertex_no_morph.instance_index)].skin_index;
+    let skin_index = mesh[vertex_no_morph.instance_index].skin_index;
     var model = bevy_pbr::skinning::skin_model(skin_index, vertex.joint_indices, vertex.joint_weights);
 #else
     // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.


### PR DESCRIPTION
This now crashes at runtime because `mesh` doesn't seem to exist for `let skin_index = mesh[vertex_no_morph.instance_index].skin_index;`.

The issue was you were always creating a uniform buffer even if it was supposed to be a storage buffer (in mesh_bindings.rs).

I also removed the `get_instance_index` calls as that workaround has been removed on bevy main.